### PR TITLE
fix: enforce valid arrival times for bus segments

### DIFF
--- a/scripts/generate_itineraries.py
+++ b/scripts/generate_itineraries.py
@@ -534,6 +534,9 @@ def select_bus_via_candidates(
         if cand["departure_stop_id"] != origin_stop_id:
             continue
         arrival_min = time_to_minutes(cand["arrival_time"])
+        depart_min = time_to_minutes(cand["departure_time"])
+        if arrival_min <= depart_min:
+            continue
         if arrival_min > latest_arrival:
             continue
         if tracker.assign(cand["service_day"], cand["route_id"], cand["trip_index"], headcount):
@@ -582,7 +585,10 @@ def select_trip_with_capacity(
     fallback: Optional[sqlite3.Row] = None
     fallback_arrival: Optional[int] = None
     for trip in trips:
+        depart_min = time_to_minutes(trip["departure_time"])
         arrival_min = time_to_minutes(trip["arrival_time"])
+        if arrival_min <= depart_min:
+            continue
         if min_arrival_min is not None and arrival_min < min_arrival_min:
             continue
         if latest_arrival_min is not None and arrival_min > latest_arrival_min:

--- a/tests/test_itinerary_views.py
+++ b/tests/test_itinerary_views.py
@@ -116,6 +116,24 @@ def test_game_bus_segments_buffer():
         assert violations == 0, "Game-bound bus segments must preserve >= 40 minute buffer"
 
 
+def test_bus_segments_travel_time_consistent():
+    with get_connection() as conn:
+        violations = conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM team_itinerary_segments
+            WHERE segment_type = 'bus'
+              AND route_id IS NOT NULL
+              AND (
+                  travel_minutes IS NULL
+                  OR travel_minutes <= 0
+                  OR start_time >= end_time
+              )
+            """
+        ).fetchone()[0]
+        assert violations == 0, "Bus segments must have departure before arrival and positive travel time"
+
+
 def test_concert_segments_exist():
     with get_connection() as conn:
         count = conn.execute(


### PR DESCRIPTION
## Summary
- skip candidate and scheduled bus trips whose arrival timestamps do not follow their departures so we never stage impossible travel legs
- regenerate itineraries and confirm they now produce only positive travel durations (SELECT COUNT(*) FROM team_itinerary_segments WHERE segment_type='bus' AND route_id IS NOT NULL AND (travel_minutes IS NULL OR travel_minutes <= 0 OR start_time >= end_time) = 0)
- add a regression guard in test_itinerary_views to prevent future timing regressions

## Testing
- python3 scripts/generate_itineraries.py
- python3 tests/test_itinerary_views.py
- python3 tests/test_transport_candidates.py
- python3 -m pytest *(fails: No module named pytest)*

Closes #2