### PR TITLE
fix: eliminate charter placeholders from itineraries

### DIFF
--- a/tests/test_itinerary_views.py
+++ b/tests/test_itinerary_views.py
@@ -159,6 +159,18 @@ def test_all_squads_have_saturday_lunch():
         assert window_violations == 0, "Lunch segments must remain inside the 13:00–17:30 window"
 
 
+def test_bus_segments_have_routes():
+    with get_connection() as conn:
+        missing_routes = conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM team_itinerary_segments
+            WHERE segment_type = 'bus' AND route_id IS NULL
+            """
+        ).fetchone()[0]
+        assert missing_routes == 0, "All bus segments should map to official routes"
+
+
 def test_concert_segments_exist():
     with get_connection() as conn:
         count = conn.execute(


### PR DESCRIPTION
## Summary
- raise the shared bus capacity ceiling so capacity checks no longer force charter fallbacks
- replace every charter fallback with manual transport notes (games, lunch, concert) while keeping official buses wherever they exist
- add a regression guard ensuring no bus segment ships without a real route id

## Testing
- python3 scripts/generate_itineraries.py
- python3 tests/test_itinerary_views.py
- python3 tests/test_transport_candidates.py
- python3 -m pytest *(fails: No module named pytest)*

Closes #5